### PR TITLE
feat: ランダムトーク（自動返信）のオプトアウト機能を追加

### DIFF
--- a/src/modules/aichat/index.ts
+++ b/src/modules/aichat/index.ts
@@ -385,6 +385,24 @@ export default class extends Module {
 
 	@bindThis
 	private async mentionHook(msg: Message) {
+		// ランダムトークのオプトアウト処理
+		if (msg.includes(['ランダムトークやめて', '話しかけないで', 'ランダムトーク停止'])) {
+			const data = msg.friend.getPerModulesData(this);
+			data.optOutRandomTalk = true;
+			msg.friend.setPerModulesData(this, data);
+			msg.reply(serifs.aichat.randomTalkOptOut);
+			return { reaction: 'love' };
+		}
+
+		// ランダムトークのオプトイン処理
+		if (msg.includes(['また話しかけて', 'ランダムトーク再開', 'ランダムトークして'])) {
+			const data = msg.friend.getPerModulesData(this);
+			data.optOutRandomTalk = false;
+			msg.friend.setPerModulesData(this, data);
+			msg.reply(serifs.aichat.randomTalkOptIn);
+			return { reaction: 'love' };
+		}
+
 		if (!msg.includes([this.name])) {
 			return false;
 		} else {
@@ -563,6 +581,13 @@ export default class extends Module {
 			return false;
 		} else if (choseNote.user.isBot) {
 			this.log('AiChat(randomtalk) end.Because message author is bot.');
+			return false;
+		}
+
+		// オプトアウトチェック
+		const perModuleData = friend.getPerModulesData(this);
+		if (perModuleData?.optOutRandomTalk === true) {
+			this.log('AiChat(randomtalk) end.Because user opted out.');
 			return false;
 		}
 

--- a/src/serifs.ts
+++ b/src/serifs.ts
@@ -393,6 +393,8 @@ export default {
 		nothing: type => `あぅ... ${type}のAPIキーが登録されてないみたいです`,
 		error: type => `うぇ...${type}でエラーが発生しちゃったみたいです。gemini-flashだと動くかも？`,
 		post: (text, type) => `${text} (${type}) #aichat`,
+		randomTalkOptOut: 'わかりました、関係ない話には関わらないようにしますね...',
+		randomTalkOptIn: 'またお話しできるの嬉しいです♪',
 	},
 
 	sleepReport: {


### PR DESCRIPTION
ユーザーがメンションで特定のキーワードを送信することで、
AIチャットのランダムトーク（自動返信）の対象から除外される機能を実装。

- オプトアウト: 「ランダムトークやめて」「話しかけないで」「ランダムトーク停止」
- オプトイン: 「また話しかけて」「ランダムトーク再開」「ランダムトークして」

設定はperModulesDataに保存されるため、Friend型の変更は不要。